### PR TITLE
ci: track nginx stable and add PR smoke test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,32 @@
+name: smoke-test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          tags: nginx-http3:smoke
+
+      - name: Check nginx version
+        run: docker run --rm nginx-http3:smoke nginx -v
+
+      - name: Test nginx configuration
+        run: docker run --rm nginx-http3:smoke nginx -t

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -34,7 +34,7 @@ jobs:
             Automated dependency pin refresh for the Dockerfile.
 
             This workflow:
-            - tracks the latest nginx mainline release from nginx.org/download/
+            - tracks the latest nginx stable release from nginx.org/download/
             - tracks the latest stable PCRE2 release from GitHub
             - tracks the latest stable zlib release from GitHub
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:latest AS builder
 
 LABEL maintainer="Woosungchoi <https://github.com/woosungchoi>"
 
-ENV NGINX_VERSION 1.29.5
+ENV NGINX_VERSION 1.30.0
 ENV PCRE_VERSION 10.47
 ENV ZLIB_VERSION 1.3.2
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ Key files:
 
 ### What gets tracked
 
-- **NGINX:** latest **mainline** release only, parsed from `https://nginx.org/download/`
-  - The updater looks for `nginx-X.Y.Z.tar.gz` entries and keeps only versions where the **minor** number `Y` is odd.
-  - Example: `1.29.x` is mainline, `1.28.x` is stable.
+- **NGINX:** latest **stable** release only, parsed from `https://nginx.org/download/`
+  - The updater looks for `nginx-X.Y.Z.tar.gz` entries and keeps only versions where the **minor** number `Y` is even.
+  - Example: `1.29.x` is mainline, `1.30.x` is stable.
 - **PCRE2:** latest stable GitHub release from `PCRE2Project/pcre2`
 - **zlib:** latest stable GitHub release from `madler/zlib`
 

--- a/scripts/update_versions.py
+++ b/scripts/update_versions.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Update Dockerfile dependency pins for nginx mainline, PCRE2, and zlib.
+"""Update Dockerfile dependency pins for nginx stable, PCRE2, and zlib.
 
 This script is intended for local use and for the scheduled GitHub Actions workflow.
 It updates the following ENV assignments in the repository Dockerfile:
 
-- NGINX_VERSION: latest nginx mainline release from https://nginx.org/download/
+- NGINX_VERSION: latest nginx stable release from https://nginx.org/download/
 - PCRE_VERSION: latest stable PCRE2 release from GitHub
 - ZLIB_VERSION: latest stable zlib release from GitHub
 
@@ -62,18 +62,18 @@ def parse_semver(version: str) -> Tuple[int, ...]:
         raise UpdateError(f"invalid version string: {version}") from exc
 
 
-def latest_nginx_mainline_version(html: str) -> str:
+def latest_nginx_stable_version(html: str) -> str:
     matches = set(re.findall(r"nginx-(\d+\.\d+\.\d+)\.tar\.gz", html))
     if not matches:
         raise UpdateError("could not find any nginx release versions on nginx.org/download/")
 
-    mainline_versions = [
-        version for version in matches if parse_semver(version)[1] % 2 == 1
+    stable_versions = [
+        version for version in matches if parse_semver(version)[1] % 2 == 0
     ]
-    if not mainline_versions:
-        raise UpdateError("could not find any nginx mainline releases (odd minor series)")
+    if not stable_versions:
+        raise UpdateError("could not find any nginx stable releases (even minor series)")
 
-    return max(mainline_versions, key=parse_semver)
+    return max(stable_versions, key=parse_semver)
 
 
 def latest_github_release_version(url: str, *, prefix_to_strip: str = "") -> str:
@@ -141,7 +141,7 @@ def main() -> int:
     current_versions = extract_current_versions(original_text)
 
     latest_versions = {
-        "NGINX_VERSION": latest_nginx_mainline_version(fetch_text(NGINX_DOWNLOAD_URL)),
+        "NGINX_VERSION": latest_nginx_stable_version(fetch_text(NGINX_DOWNLOAD_URL)),
         "PCRE_VERSION": latest_github_release_version(PCRE2_RELEASE_URL, prefix_to_strip="pcre2-"),
         "ZLIB_VERSION": latest_github_release_version(ZLIB_RELEASE_URL, prefix_to_strip="v"),
     }


### PR DESCRIPTION
## Summary
- switch the nginx updater policy from mainline releases to stable releases
- update `NGINX_VERSION` from `1.29.5` to stable `1.30.0`
- document the stable-release tracking policy in README and updater PR text
- add a pull-request smoke workflow that builds the image without publishing it and checks `nginx -v` / `nginx -t`

## Validation
- resolved upstream nginx versions from `https://nginx.org/download/`: stable `1.30.0`, mainline `1.29.8`
- ran `python3 scripts/update_versions.py --dry-run`; all pins unchanged after the update
- ran `python3 scripts/update_versions.py --check`; exited successfully with no pending updates
- parsed all GitHub Actions workflow YAML files

## Rollback
- revert this PR to return to the previous mainline tracking policy and remove the PR smoke workflow
