### PR TITLE
ci: add publish guardrails and clean Dockerfile

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -6,6 +6,10 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   packages: write
@@ -18,6 +22,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -112,6 +117,8 @@ jobs:
             VCS_REF=${{ env.VCS_REF }}
           push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           sbom: true
           provenance: mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ FROM alpine:latest AS builder
 
 LABEL maintainer="Woosungchoi <https://github.com/woosungchoi>"
 
-ENV NGINX_VERSION 1.30.2
-ENV PCRE_VERSION 10.47
-ENV ZLIB_VERSION 1.3.2
+ENV NGINX_VERSION=1.30.2
+ENV PCRE_VERSION=10.47
+ENV ZLIB_VERSION=1.3.2
 
 RUN set -x; \
   CONFIG="\
@@ -213,8 +213,9 @@ STOPSIGNAL SIGTERM
 CMD ["nginx", "-g", "daemon off;"]
 
 # Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
 ARG VCS_REF
 
-LABEL org.label-schema.build-date=$BUILD_DATE \
-  org.label-schema.vcs-ref=$VCS_REF \
+LABEL org.label-schema.build-date="$BUILD_DATE" \
+  org.label-schema.vcs-ref="$VCS_REF" \
   org.label-schema.vcs-url="https://github.com/woosungchoi/docker-nginx-brotli.git"


### PR DESCRIPTION
## Summary
- serialize publish runs by ref without cancelling in-flight image pushes
- add a 120-minute publish job timeout and GitHub Actions Buildx cache
- clean Dockerfile ENV syntax and declare BUILD_DATE before metadata labels

## Validation
- PyYAML workflow parse
- actionlint
- git diff --check
- docker buildx build --check with BUILD_DATE/VCS_REF args: no warnings
- static scan of added lines
- independent review passed