### PR TITLE
fix: parse Dockerfile ENV pins with equals syntax

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -114,8 +114,8 @@ jobs:
           BASE_DOCKERFILE=$(git show "origin/$BASE_REF:Dockerfile")
           HEAD_DOCKERFILE=$(git show "origin/$HEAD_REF:Dockerfile")
 
-          old_nginx=$(printf '%s\n' "$BASE_DOCKERFILE" | awk '/^ENV NGINX_VERSION / {print $3}')
-          new_nginx=$(printf '%s\n' "$HEAD_DOCKERFILE" | awk '/^ENV NGINX_VERSION / {print $3}')
+          old_nginx=$(printf '%s\n' "$BASE_DOCKERFILE" | sed -nE 's/^ENV[[:space:]]+NGINX_VERSION([[:space:]]+|=)([^[:space:]]+).*/\2/p')
+          new_nginx=$(printf '%s\n' "$HEAD_DOCKERFILE" | sed -nE 's/^ENV[[:space:]]+NGINX_VERSION([[:space:]]+|=)([^[:space:]]+).*/\2/p')
 
           if [ -z "$old_nginx" ] || [ -z "$new_nginx" ]; then
             echo "manual=true" >> "$GITHUB_OUTPUT"

--- a/scripts/update_versions.py
+++ b/scripts/update_versions.py
@@ -32,9 +32,9 @@ USER_AGENT = "docker-nginx-brotli-version-updater/1.0"
 TIMEOUT_SECONDS = 30
 
 VERSION_PATTERNS = {
-    "NGINX_VERSION": re.compile(r"^(ENV\s+NGINX_VERSION\s+)(\S+)(\s*)$", re.MULTILINE),
-    "PCRE_VERSION": re.compile(r"^(ENV\s+PCRE_VERSION\s+)(\S+)(\s*)$", re.MULTILINE),
-    "ZLIB_VERSION": re.compile(r"^(ENV\s+ZLIB_VERSION\s+)(\S+)(\s*)$", re.MULTILINE),
+    "NGINX_VERSION": re.compile(r"^(ENV\s+NGINX_VERSION(?:\s+|=))(\S+)(\s*)$", re.MULTILINE),
+    "PCRE_VERSION": re.compile(r"^(ENV\s+PCRE_VERSION(?:\s+|=))(\S+)(\s*)$", re.MULTILINE),
+    "ZLIB_VERSION": re.compile(r"^(ENV\s+ZLIB_VERSION(?:\s+|=))(\S+)(\s*)$", re.MULTILINE),
 }
 
 


### PR DESCRIPTION
## Summary
- Fix update_versions.py to parse Dockerfile ENV pins written as ENV KEY=value as well as ENV KEY value
- Fix the follow-up workflow policy check to extract NGINX_VERSION from both ENV syntaxes

## Why
The scheduled dependency update workflow failed because Dockerfile currently uses ENV NGINX_VERSION=1.30.2, while the updater only matched space-separated ENV assignments.

## Verification
- python3 scripts/update_versions.py --dry-run
- python3 -m py_compile scripts/update_versions.py
- inline regression check for equals and space-separated ENV syntax
- uvx pyrefly check scripts/update_versions.py --ignore-missing-imports '*' --output-format min-text --summary=full
- code-review-graph update && code-review-graph detect-changes --base HEAD --brief