### PR TITLE
chore: update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Set environment variables
         env:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Build image for smoke test
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.2.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.x'
 
@@ -28,7 +28,7 @@ jobs:
 
       - name: Create pull request if Dockerfile changed
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update nginx, pcre2, and zlib versions'


### PR DESCRIPTION
## Summary
- Update remaining Node 20-based GitHub Actions in update-versions and smoke-test workflows
- Bump checkout in publish workflow from v6.0.2 to v6.0.3 for consistency

## Updated actions
- actions/checkout: v4/v6.0.2 -> v6.0.3
- actions/setup-python: v5 -> v6.2.0
- peter-evans/create-pull-request: v7 -> v8.1.1
- docker/setup-buildx-action: v3 -> v4.1.0
- docker/build-push-action: v6 -> v7.2.0

## Verification
- YAML parsed for all workflow files
- actionlint .github/workflows/*.yml
- code-review-graph update && code-review-graph detect-changes --base HEAD --brief