### PR TITLE
ci: add broader repository checks

### DIFF
--- a/.github/workflows/auto-merge-dependency-pr.yml
+++ b/.github/workflows/auto-merge-dependency-pr.yml
@@ -104,8 +104,8 @@ jobs:
           BASE_DOCKERFILE=$(git show "origin/$BASE_REF:Dockerfile")
           HEAD_DOCKERFILE=$(git show "origin/$HEAD_REF:Dockerfile")
 
-          old_nginx=$(printf '%s\n' "$BASE_DOCKERFILE" | awk '/^ENV NGINX_VERSION / {print $3}')
-          new_nginx=$(printf '%s\n' "$HEAD_DOCKERFILE" | awk '/^ENV NGINX_VERSION / {print $3}')
+          old_nginx=$(printf '%s\n' "$BASE_DOCKERFILE" | sed -nE 's/^ENV[[:space:]]+NGINX_VERSION([[:space:]]+|=)([^[:space:]]+).*/\2/p')
+          new_nginx=$(printf '%s\n' "$HEAD_DOCKERFILE" | sed -nE 's/^ENV[[:space:]]+NGINX_VERSION([[:space:]]+|=)([^[:space:]]+).*/\2/p')
 
           if [ -z "$old_nginx" ] || [ -z "$new_nginx" ]; then
             echo "Could not resolve NGINX_VERSION from Dockerfile."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,125 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-and-source-checks:
+    name: workflow and source checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.x'
+
+      - name: Validate workflow YAML syntax
+        run: |
+          set -euo pipefail
+          ruby -e 'ARGV.each { |path| require "yaml"; YAML.load_file(path); puts "yaml ok: #{path}" }' .github/workflows/*.yml
+
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: '1.7.12'
+        run: |
+          set -euo pipefail
+          curl -fsSLo /tmp/actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
+          sudo install -m 0755 /tmp/actionlint /usr/local/bin/actionlint
+          actionlint -version
+
+      - name: Lint GitHub Actions workflows
+        run: actionlint .github/workflows/*.yml
+
+      - name: Guard against Node 20-based action versions
+        run: |
+          set -euo pipefail
+          if grep -RInE 'uses: (actions/checkout@v[1-5]|actions/setup-python@v[1-5]|docker/setup-buildx-action@v[1-3]|docker/build-push-action@v[1-6]|peter-evans/create-pull-request@v[1-7])([^0-9.]|$)' .github/workflows; then
+            echo "Found GitHub Action pins known to run on deprecated Node.js runtimes." >&2
+            exit 1
+          fi
+
+      - name: Compile Python scripts
+        run: python3 -m py_compile scripts/update_versions.py
+
+      - name: Check dependency updater dry run
+        run: python3 scripts/update_versions.py --dry-run
+
+      - name: Regression test Dockerfile ENV pin parser
+        run: |
+          python3 - <<'PY'
+          from scripts.update_versions import extract_current_versions, replace_versions
+
+          samples = [
+              "ENV NGINX_VERSION=1.0.0\nENV PCRE_VERSION=10.0\nENV ZLIB_VERSION=1.2.3\n",
+              "ENV NGINX_VERSION 1.0.0\nENV PCRE_VERSION 10.0\nENV ZLIB_VERSION 1.2.3\n",
+          ]
+          replacement = {
+              "NGINX_VERSION": "1.30.2",
+              "PCRE_VERSION": "10.47",
+              "ZLIB_VERSION": "1.3.2",
+          }
+
+          for text in samples:
+              assert extract_current_versions(text) == {
+                  "NGINX_VERSION": "1.0.0",
+                  "PCRE_VERSION": "10.0",
+                  "ZLIB_VERSION": "1.2.3",
+              }
+              updated = replace_versions(text, replacement)
+              assert "1.30.2" in updated
+              assert "10.47" in updated
+              assert "1.3.2" in updated
+
+          print("Dockerfile ENV pin parser regression checks passed.")
+          PY
+
+      - name: Check shell hook syntax
+        run: bash -n hooks/build hooks/push
+
+      - name: Install ShellCheck
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends shellcheck
+
+      - name: Lint shell hooks
+        run: shellcheck hooks/build hooks/push
+
+      - name: Check Dockerfile with BuildKit
+        run: docker buildx build --check --file Dockerfile .
+
+      - name: Lint Dockerfile with Hadolint
+        run: docker run --rm -i hadolint/hadolint:v2.14.0 hadolint --failure-threshold error - < Dockerfile
+
+  trivy-repository-scan:
+    name: trivy repository scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.3
+
+      - name: Scan repository configuration and secrets
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: misconfig,secret
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          format: table

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -28,5 +28,34 @@ jobs:
       - name: Check nginx version
         run: docker run --rm nginx-http3:smoke nginx -v
 
-      - name: Test nginx configuration
+      - name: Test default nginx configuration
         run: docker run --rm nginx-http3:smoke nginx -t
+
+      - name: Test recommended nginx configuration
+        run: docker run --rm -v "${PWD}/nginx.conf:/etc/nginx/nginx.conf:ro" nginx-http3:smoke nginx -t
+
+      - name: Test HTTP/3 example configuration
+        run: docker run --rm -v "${PWD}/h3.nginx.conf:/etc/nginx/conf.d/h3.nginx.conf:ro" nginx-http3:smoke nginx -t
+
+      - name: Test HTTP response
+        run: |
+          set -euo pipefail
+          container_id=$(docker run -d -p 127.0.0.1::80 nginx-http3:smoke)
+          trap 'docker rm -f "${container_id}" >/dev/null 2>&1 || true' EXIT
+
+          host_port=$(docker port "${container_id}" 80/tcp | sed -E 's/^.*:([0-9]+)$/\1/')
+          status=""
+          for attempt in $(seq 1 30); do
+            status=$(curl -sS -o /tmp/nginx-smoke-response.html -w '%{http_code}' "http://127.0.0.1:${host_port}/" || true)
+            case "${status}" in
+              2*|3*|4*) break ;;
+            esac
+
+            if [ "${attempt}" -eq 30 ]; then
+              docker logs "${container_id}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "HTTP smoke status: ${status}"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# Nginx master process intentionally starts as root to bind privileged ports 80/443,
+# then nginx.conf runs worker processes as the nginx user.
+DS-0002


### PR DESCRIPTION
## Summary
- add a dedicated ci workflow for workflow YAML validation, actionlint, Node runtime guard, Python updater regression checks, shell hook checks, BuildKit Dockerfile checks, Hadolint, and Trivy misconfiguration/secret scanning
- expand smoke-test to validate default, recommended, and HTTP/3 nginx configs plus runtime HTTP reachability
- make dependency auto-merge nginx version policy parse both `ENV KEY=value` and `ENV KEY value` Dockerfile syntax

## Verification
- ruby YAML parse for `.github/workflows/*.yml`
- `actionlint .github/workflows/*.yml`
- `python3 -m py_compile scripts/update_versions.py`
- `python3 scripts/update_versions.py --dry-run`
- Dockerfile ENV parser regression snippet
- `bash -n hooks/build hooks/push`
- ShellCheck via Docker
- `docker buildx build --check --file Dockerfile .`
- Hadolint via Docker with `--failure-threshold error`
- Trivy fs scan via Docker with `.trivyignore`
- local Docker build and enhanced nginx smoke checks
