### PR TITLE
ci: run Trivy scan via Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,14 @@ jobs:
         uses: actions/checkout@v6.0.3
 
       - name: Scan repository configuration and secrets
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          scan-type: fs
-          scan-ref: .
-          scanners: misconfig,secret
-          severity: HIGH,CRITICAL
-          exit-code: '1'
-          ignore-unfixed: true
-          trivyignores: .trivyignore
-          format: table
+        run: |
+          docker run --rm \
+            -v "${PWD}:/src" \
+            aquasec/trivy:0.71.0 \
+            fs \
+            --ignorefile /src/.trivyignore \
+            --scanners misconfig,secret \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            --ignore-unfixed \
+            /src


### PR DESCRIPTION
## Summary
- replace trivy-action setup with a pinned Trivy Docker image invocation
- keep the same misconfiguration/secret scan and `.trivyignore` policy

## Why
- the master CI run failed because `aquasecurity/trivy-action` could not install its default Trivy binary from GitHub during setup
- running the scanner through `aquasec/trivy:0.71.0` avoids that setup path and matched the local verification

## Verification
- ruby YAML parse for `.github/workflows/*.yml`
- `actionlint .github/workflows/*.yml`
- local Docker Trivy scan with `.trivyignore`
