### PR TITLE
ci: retry actionlint download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           ACTIONLINT_VERSION: '1.7.12'
         run: |
           set -euo pipefail
-          curl -fsSLo /tmp/actionlint.tar.gz \
+          curl --retry 5 --retry-delay 5 --retry-all-errors -fsSLo /tmp/actionlint.tar.gz \
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
           sudo install -m 0755 /tmp/actionlint /usr/local/bin/actionlint


### PR DESCRIPTION
## Summary
- add curl retry handling around the actionlint release download

## Why
- the master CI run hit a transient GitHub 504 while downloading actionlint
- retries keep the new checks strict without making CI flaky on temporary release asset errors

## Verification
- ruby YAML parse for `.github/workflows/*.yml`
- `actionlint .github/workflows/*.yml`
